### PR TITLE
Add support for catchall & passthrough generation

### DIFF
--- a/src/lib/generators/object.ts
+++ b/src/lib/generators/object.ts
@@ -2,6 +2,7 @@ import { get_semantic_flag } from "../semantics.js";
 import { GenerationContext, generate } from "../generate.js";
 import { GeneratorDefinitionFactory } from "../zocker.js";
 import { z } from "zod";
+import { faker } from "@faker-js/faker";
 
 export const ObjectGenerator: GeneratorDefinitionFactory<z.ZodObject<any>> = (
 	options = {}
@@ -18,8 +19,8 @@ const generate_object = <T extends z.ZodRawShape>(
 	generation_context: GenerationContext<z.ZodObject<T>>
 ): z.infer<z.ZodObject<T>> => {
 	type Shape = z.infer<typeof object_schema>;
-	type Key = keyof Shape;
 	type Value = Shape[keyof Shape];
+	type Key = string | number | symbol;
 
 	const mock_entries = [] as [Key, Value][];
 
@@ -42,6 +43,35 @@ const generate_object = <T extends z.ZodRawShape>(
 			generation_context.semantic_context = prev_semantic_context;
 		}
 	});
+
+	let catchall_schema: z.ZodSchema | null = object_schema._def.catchall;
+	if (catchall_schema instanceof z.ZodNever) catchall_schema = null;
+	const is_passthrough = object_schema._def.unknownKeys === "passthrough";
+	if (is_passthrough && !catchall_schema) catchall_schema = z.any()
+
+	if (catchall_schema) {
+		const key_schema = z.union([z.string(), z.number(), z.symbol()]);
+		const num_additional_keys = faker.datatype.number({ min: 0, max: 10 });
+		try {
+			for (let i = 0; i < num_additional_keys; i++) {
+				const prev_semantic_context = generation_context.semantic_context;
+				let key: Key;
+				try {
+					generation_context.semantic_context = "key"
+					key = generate(key_schema, generation_context);
+				} finally {
+					generation_context.semantic_context = prev_semantic_context;
+				}
+
+				const value = generate(catchall_schema, generation_context);
+
+				//Prepend to mock_entries, 
+				//so that the catchall keys would be overwritten by the original keys in case of a collision
+				mock_entries.unshift([key, value]);
+			}
+		} catch (e) { }
+	}
+
 
 	return Object.fromEntries(mock_entries) as Shape;
 };

--- a/tests/catchall.test.ts
+++ b/tests/catchall.test.ts
@@ -1,0 +1,13 @@
+import { describe } from "vitest";
+import { z } from "zod";
+import { test_schema_generation } from "./utils";
+
+const catchall_schemas = {
+    "catchall": z.object({ a: z.string(), b: z.number() }).catchall(z.string()),
+    "catchall passthrough": z.object({ a: z.string(), b: z.number() }).passthrough().catchall(z.string()),
+    "passthrough": z.object({ a: z.string(), b: z.number() }).passthrough(),
+} as const;
+
+describe("Catchall generation", () => {
+    test_schema_generation(catchall_schemas);
+});


### PR DESCRIPTION
This addresses #1, by automatically attempting to generate extra values using the `catchall` schema, if it's provided.
If there is no `catchall`, but `passthrough` is set, then it will treat it as equivalent to `catchall(z.any())`. 

The extra properties are guaranteed to never override the explicitly specified ones.