### PR TITLE
Fix `z.iso.datetime` generator when using `offset: true`

### DIFF
--- a/.changeset/cold-dots-drum.md
+++ b/.changeset/cold-dots-drum.md
@@ -1,0 +1,5 @@
+---
+"zocker": patch
+---
+
+Fix incorrect format when generating values for `z.iso.datetime({ offset: true })`

--- a/packages/zocker/src/lib/v4/generators/string/iso.ts
+++ b/packages/zocker/src/lib/v4/generators/string/iso.ts
@@ -9,7 +9,7 @@ const iso_datetime_generator: Generator<z.$ZodISODateTime> = (schema, ctx) => {
 
 	const defined_precision = schema._zod.def.precision;
 	let precision = defined_precision != null ? defined_precision : faker.number.int({ min: 0, max: 6 });
-	let datetime = faker.date.recent().toISOString();
+	let datetime = faker.date.recent({ days: 100 }).toISOString();
 
 	// remove the precision (if present).
 	const PRECISION_REGEX = /(\.\d+)?Z/;
@@ -43,12 +43,9 @@ export const ISODateTimeGenerator: InstanceofGeneratorDefinition<z.$ZodISODateTi
 };
 
 const iso_date_generator: Generator<z.$ZodISODate> = (schema, ctx) => {
-	const pattern = schema._zod.def.pattern!;
-
-	const randexp = new Randexp(pattern);
-	randexp.randInt = (min: number, max: number) =>
-		faker.number.int({ min, max });
-	return randexp.gen();
+	const date = faker.date.recent({ days: 100 }).toISOString().split("T")[0];
+	if(!date) throw new Error("INTERNAL ERROR - ISODateGenerator - `date` is undefined - Please open an issue.");
+	return date;
 };
 
 export const ISODateGenerator: InstanceofGeneratorDefinition<z.$ZodISODate> = {
@@ -63,7 +60,9 @@ const iso_time_generator: Generator<z.$ZodISOTime> = (schema, ctx) => {
 	const randexp = new Randexp(pattern);
 	randexp.randInt = (min: number, max: number) =>
 		faker.number.int({ min, max });
-	return randexp.gen();
+	const time = randexp.gen();
+
+	return time;	
 };
 
 export const ISOTimeGenerator: InstanceofGeneratorDefinition<z.$ZodISOTime> = {

--- a/packages/zocker/src/lib/v4/utils/random.ts
+++ b/packages/zocker/src/lib/v4/utils/random.ts
@@ -25,6 +25,9 @@ export function weighted_pick<A, B>(
 	return first ? option_1 : option_2;
 }
 
+/**
+ * @deprecated Use `faker.datatype.boolean({ probability })` directly
+ */
 export function weighted_random_boolean(true_probability: number): boolean {
 	return faker.datatype.boolean({ probability: true_probability });
 }

--- a/packages/zocker/tests/v4/iso.test.ts
+++ b/packages/zocker/tests/v4/iso.test.ts
@@ -2,18 +2,41 @@ import { describe } from "vitest";
 import { z } from "zod/v4";
 import { test_schema_generation } from "./utils";
 
-const iso_schemas = {
-	"iso date": z.iso.date(),
+const iso_datetime_schemas = {
 	"iso datetime": z.iso.datetime(),
-	"iso time": z.iso.time(),
-	"iso duration": z.iso.duration(),
-
 	"iso datetime with offset": z.iso.datetime({ offset: true }),
 	"iso datetime with precision": z.iso.datetime({ precision: 2 }),
 	"iso datetime with precision 0": z.iso.datetime({ precision: 0 }),
 	"iso datetime with precision and offset": z.iso.datetime({ precision: 2, offset: true })
 };
 
-describe("ISO generation", () => {
-	test_schema_generation(iso_schemas);
+const iso_date_schemas = {
+	"iso date": z.iso.date(),
+};
+
+const iso_time_schemas = {
+	"iso time": z.iso.time(),
+	"iso time with precision": z.iso.time({ precision: 7 }),
+	"iso time with precision 0": z.iso.time({ precision: 0 })
+};
+
+const iso_duration_schemas = {
+	"iso duration": z.iso.duration(),
+	"iso duration with pattern": z.iso.duration({ pattern: z.regexes.duration }),
+};
+
+describe("ISO Datetime generation", () => {
+	test_schema_generation(iso_datetime_schemas);
+});
+
+describe("ISO Date generation", () => {
+	test_schema_generation(iso_date_schemas);
+});
+
+describe("ISO Time generation", () => {
+	test_schema_generation(iso_time_schemas);
+});
+
+describe("ISO Duration generation", () => {
+	test_schema_generation(iso_duration_schemas);
 });

--- a/packages/zocker/tests/v4/iso.test.ts
+++ b/packages/zocker/tests/v4/iso.test.ts
@@ -6,7 +6,12 @@ const iso_schemas = {
 	"iso date": z.iso.date(),
 	"iso datetime": z.iso.datetime(),
 	"iso time": z.iso.time(),
-	"iso duration": z.iso.duration()
+	"iso duration": z.iso.duration(),
+
+	"iso datetime with offset": z.iso.datetime({ offset: true }),
+	"iso datetime with precision": z.iso.datetime({ precision: 2 }),
+	"iso datetime with precision 0": z.iso.datetime({ precision: 0 }),
+	"iso datetime with precision and offset": z.iso.datetime({ precision: 2, offset: true })
 };
 
 describe("ISO generation", () => {


### PR DESCRIPTION
Closes #29 

Zocker `2.0` changed how `z.iso.datetime` was generated. This caused incorrect results when generating values, especially with `offset: true`. 

This PR changes the generation behavior of `z.iso.datetime` back to that in Zocker `1.4.x`. The Date Generation uses `faker.date.recent({ days: 100 })`. 

**Behavior with `offset`**

```ts
z.iso.datetime({ offset: true })
// 2025-03-03T06:46:39+20:19
// 2025-04-17T08:20:47.2599-01:29 (arbitrary precision)

z.iso.datetime({ offset: true, precision: 0 })
// 2025-03-03T06:46:39+20:19
```

**Behavior with `precision`**
```ts
z.iso.datetime({ precision: 0 })
// 2025-03-15T19:59:48Z

z.iso.datetime({ precision: 2 })
// 2025-04-30T06:58:35.28Z

z.iso.datetime()
// 2025-03-24T22:51:32.2079Z (arbitrary precision)
```