### PR TITLE
Add `z.guid` Generator

### DIFF
--- a/.changeset/swift-rings-taste.md
+++ b/.changeset/swift-rings-taste.md
@@ -1,0 +1,5 @@
+---
+"zocker": patch
+---
+
+Implement `z.guid` generator

--- a/packages/zocker/src/lib/v4/default_generators.ts
+++ b/packages/zocker/src/lib/v4/default_generators.ts
@@ -44,7 +44,8 @@ import {
 	PipeGenerator,
 	EmojiGenerator,
 	Base64Generator,
-	Base64URLGenerator
+	Base64URLGenerator,
+	GUIDGenerator
 } from "./generators/index.js";
 
 export const default_generators: InstanceofGeneratorDefinition<any>[] = [
@@ -62,6 +63,7 @@ export const default_generators: InstanceofGeneratorDefinition<any>[] = [
 	ISODurationGenerator,
 	EmailGenerator,
 	E164Generator,
+	GUIDGenerator,
 	UUIDGenerator,
 	IPv4Generator,
 	IPv6Generator,

--- a/packages/zocker/src/lib/v4/generators/index.ts
+++ b/packages/zocker/src/lib/v4/generators/index.ts
@@ -22,7 +22,7 @@ export { ReadonlyGenerator } from "./readonly.js";
 export { StringGenerator } from "./string/plain.js";
 export { CUIDGenerator, CUID2Generator } from "./string/cuid.js";
 export { IPv4Generator, IPv6Generator } from "./string/ip.js";
-export { UUIDGenerator } from "./string/uuid.js";
+export { UUIDGenerator, GUIDGenerator } from "./string/uuid.js";
 export { E164Generator } from "./string/e164.js";
 export { EmailGenerator } from "./string/email.js";
 export {

--- a/packages/zocker/src/lib/v4/generators/string/uuid.ts
+++ b/packages/zocker/src/lib/v4/generators/string/uuid.ts
@@ -18,3 +18,18 @@ export const UUIDGenerator: InstanceofGeneratorDefinition<z.$ZodUUID> = {
 	schema: z.$ZodUUID as any,
 	generator: uuid_generator
 };
+
+
+const guid_generator: Generator<z.$ZodGUID> = (schema, ctx) => {
+	const pattern = schema._zod.def.pattern ?? z.regexes.guid;
+
+	const randexp = new Randexp(pattern);
+	randexp.randInt = (min: number, max: number) => faker.number.int({ min, max });
+	return randexp.gen();
+};
+
+export const GUIDGenerator: InstanceofGeneratorDefinition<z.$ZodGUID> = {
+	match: "instanceof",
+	schema: z.$ZodGUID as any,
+	generator: guid_generator
+};

--- a/packages/zocker/tests/v4/uuid.test.ts
+++ b/packages/zocker/tests/v4/uuid.test.ts
@@ -18,6 +18,10 @@ const uuidv7_schemas = {
 	"plain uuidv7": z.uuidv7()
 };
 
+const guid_schemas = {
+	"plain guid": z.guid()
+}
+
 describe("UUID generation", () => {
 	test_schema_generation(uuid_schemas);
 });
@@ -32,4 +36,8 @@ describe("UUIDv6 generation", () => {
 
 describe("UUIDv7 generation", () => {
 	test_schema_generation(uuidv7_schemas);
+});
+
+describe("GUID generation", () => {
+	test_schema_generation(guid_schemas);
 });


### PR DESCRIPTION
This PR adds a generator for the previously overlooked `z.guid` schema