### PR TITLE
Support deprecated string formats

### DIFF
--- a/.changeset/bitter-llamas-relax.md
+++ b/.changeset/bitter-llamas-relax.md
@@ -1,0 +1,5 @@
+---
+"zocker": patch
+---
+
+Implemet `z.ksuid()` generator

--- a/.changeset/spicy-dodos-end.md
+++ b/.changeset/spicy-dodos-end.md
@@ -1,0 +1,5 @@
+---
+"zocker": patch
+---
+
+fix: Legacy string formats, such as `z.string().email()` are supported again. However, you should still upgrade to the dedicated schemas, such as `z.email()` as soon as possible.

--- a/packages/zocker/src/lib/v4/default_generators.ts
+++ b/packages/zocker/src/lib/v4/default_generators.ts
@@ -45,10 +45,12 @@ import {
 	EmojiGenerator,
 	Base64Generator,
 	Base64URLGenerator,
-	GUIDGenerator
+	GUIDGenerator,
+	KSUIDGenerator
 } from "./generators/index.js";
 
 export const default_generators: InstanceofGeneratorDefinition<any>[] = [
+	KSUIDGenerator,
 	Base64Generator,
 	Base64URLGenerator,
 	EmojiGenerator,

--- a/packages/zocker/src/lib/v4/generators/index.ts
+++ b/packages/zocker/src/lib/v4/generators/index.ts
@@ -38,3 +38,4 @@ export { URLGenerator } from "./string/url.js";
 export { PipeGenerator } from "./pipe.js";
 export { EmojiGenerator } from "./string/emoji.js";
 export { Base64Generator, Base64URLGenerator } from "./string/base64.js";
+export { KSUIDGenerator } from "./string/ksuid.js";

--- a/packages/zocker/src/lib/v4/generators/string/ksuid.ts
+++ b/packages/zocker/src/lib/v4/generators/string/ksuid.ts
@@ -1,0 +1,43 @@
+import * as z from "zod/v4/core";
+import { Generator } from "../../generate.js";
+import { InstanceofGeneratorDefinition } from "../../zocker.js";
+import { getLengthConstraints } from "./length-constraints.js";
+import { getContentConstraints } from "./content-constraints.js";
+import RandExp from "randexp";
+
+const KSUID_LENGTH = 27;
+
+const ksuid_generator: Generator<z.$ZodKSUID> = (schema, ctx) => {
+
+    const length_constraints = getLengthConstraints(schema);
+    
+    const min_length_too_long = length_constraints.min > KSUID_LENGTH;
+    const max_length_too_short = length_constraints.max < KSUID_LENGTH;
+    const exact_length_too_long =
+        length_constraints.exact != null &&
+        length_constraints.exact > KSUID_LENGTH;
+    const exact_length_too_short =
+        length_constraints.exact != null &&
+        length_constraints.exact < KSUID_LENGTH;
+    
+    if (
+        min_length_too_long ||
+        max_length_too_short ||
+        exact_length_too_long ||
+        exact_length_too_short
+    ) {
+        throw new Error(`KSUID must be exactly ${KSUID_LENGTH} characters long`);
+    }
+    
+    const content_constraints = getContentConstraints(schema);
+    
+    const ksuid = new RandExp(z.regexes.ksuid);
+    return ksuid.gen();
+
+};
+
+export const KSUIDGenerator: InstanceofGeneratorDefinition<z.$ZodKSUID> = {
+	match: "instanceof",
+	schema: z.$ZodKSUID as any,
+	generator: ksuid_generator
+};

--- a/packages/zocker/src/lib/v4/generators/string/legacy.ts
+++ b/packages/zocker/src/lib/v4/generators/string/legacy.ts
@@ -10,16 +10,162 @@ import { generate, GenerationContext } from "../../generate.js";
  */
 export function legacyFormatString(schema: z.$ZodString, ctx: GenerationContext<any>): string | null {
     const checks = schema._zod.def.checks ?? [];
-    
-    const guid_checks = checks.filter((c) => c instanceof z4.ZodGUID);
-    const uuid_checks = checks.filter((c) => c instanceof z4.ZodUUID);
+    const format_checks = checks.filter(
+        (check) => check instanceof z4.ZodStringFormat
+    )
 
+
+    const date_checks = format_checks.filter(
+        (check) => check instanceof z4.iso.ZodISODate
+    );
+    if (date_checks.length > 0) {
+        const date_schema = z4.iso.date();
+        date_schema._zod.def.checks = checks;
+        return generate(date_schema, ctx);
+    }
+
+    const datetime_checks = format_checks.filter(
+        (check) => check instanceof z4.iso.ZodISODateTime
+    );
+    if (datetime_checks.length > 0) {
+        const datetime_schema = z4.iso.datetime();
+        datetime_schema._zod.def.checks = checks;
+        return generate(datetime_schema, ctx);
+    }
+
+    const duration_checks = format_checks.filter(
+        (check) => check instanceof z4.iso.ZodISODuration
+    );
+    if (duration_checks.length > 0) {
+        const duration_schema = z4.iso.duration();
+        duration_schema._zod.def.checks = checks;
+        return generate(duration_schema, ctx);
+    }
+
+    const time_checks = format_checks.filter(
+        (check) => check instanceof z4.iso.ZodISOTime
+    );
+    if (time_checks.length > 0) {
+        const time_schema = z4.iso.time();
+        time_schema._zod.def.checks = checks;
+        return generate(time_schema, ctx);
+    }
+
+    const email_checks = format_checks.filter(
+        (check) => check instanceof z4.ZodEmail
+    );
+    if (email_checks.length > 0) {
+        const email_schema = z4.email();
+        email_schema._zod.def.checks = checks;
+        return generate(email_schema, ctx);
+    }
+
+    const guid_checks = checks.filter((c) => c instanceof z4.ZodGUID);
+    if (guid_checks.length > 0) {
+        const guid_schema = z4.guid()
+        guid_schema._zod.def.checks = checks;
+        return generate(guid_schema, ctx);
+    }
+
+    const uuid_checks = checks.filter((c) => c instanceof z4.ZodUUID);
     if (uuid_checks.length > 0) {
-        
         const uuid_schema = z4.uuid({ version: uuid_checks[0]!.def.version })
+        uuid_schema._zod.def.checks = checks;
         return generate(uuid_schema, ctx);
     }
 
+    const url_checks = checks.filter((c) => c instanceof z4.ZodURL);
+    if (url_checks.length > 0) {
+        const url_schema = z4.url();
+        url_schema._zod.def.checks = checks;
+        return generate(url_schema, ctx);
+    }
 
-	return null;
+    const cuid_checks = checks.filter((c) => c instanceof z4.ZodCUID);
+    if (cuid_checks.length > 0) {
+        const cuid_schema = z4.cuid();
+        cuid_schema._zod.def.checks = checks;
+        return generate(cuid_schema, ctx);
+    }
+
+    const cuid2_checks = checks.filter((c) => c instanceof z4.ZodCUID2);
+    if (cuid2_checks.length > 0) {
+        const cuid2_schema = z4.cuid2();
+        cuid2_schema._zod.def.checks = checks;
+        return generate(cuid2_schema, ctx);
+    }
+
+    const ulid_checks = checks.filter((c) => c instanceof z4.ZodULID);
+    if (ulid_checks.length > 0) {
+        const ulid_schema = z4.ulid();
+        ulid_schema._zod.def.checks = checks;
+        return generate(ulid_schema, ctx);
+    }
+
+    const emoji_checks = checks.filter((c) => c instanceof z4.ZodEmoji);
+    if (emoji_checks.length > 0) {
+        const emoji_schema = z4.emoji();
+        emoji_schema._zod.def.checks = checks;
+        return generate(emoji_schema, ctx);
+    }
+
+    const nanoid_checks = checks.filter((c) => c instanceof z4.ZodNanoID);
+    if (nanoid_checks.length > 0) {
+        const nanoid_schema = z4.nanoid();
+        nanoid_schema._zod.def.checks = checks;
+        return generate(nanoid_schema, ctx);
+    }
+
+    const ipv6_checks = checks.filter((c) => c instanceof z4.ZodIPv6);
+    if (ipv6_checks.length > 0) {
+        const ipv6_schema = z4.ipv6();
+        ipv6_schema._zod.def.checks = checks;
+        return generate(ipv6_schema, ctx);
+    }
+
+    const ipv4_checks = checks.filter((c) => c instanceof z4.ZodIPv4);
+    if (ipv4_checks.length > 0) {
+        const ipv4_schema = z4.ipv4();
+        ipv4_schema._zod.def.checks = checks;
+        return generate(ipv4_schema, ctx);
+    }
+
+    const e164_checks = checks.filter((c) => c instanceof z4.ZodE164);
+    if (e164_checks.length > 0) {
+        const e164_schema = z4.e164();
+        e164_schema._zod.def.checks = checks;
+        return generate(e164_schema, ctx);
+    }
+
+    const cidrv4_checks = checks.filter((c) => c instanceof z4.ZodCIDRv4);
+    if (cidrv4_checks.length > 0) {
+        const cidrv4_schema = z4.cidrv4();
+        cidrv4_schema._zod.def.checks = checks;
+        return generate(cidrv4_schema, ctx);
+    }
+
+    const cidrv6_checks = checks.filter((c) => c instanceof z4.ZodCIDRv6);
+    if (cidrv6_checks.length > 0) {
+        const cidrv6_schema = z4.cidrv6();
+        cidrv6_schema._zod.def.checks = checks;
+        return generate(cidrv6_schema, ctx);
+    }
+
+    const base64_url_checks = checks.filter((c) => c instanceof z4.ZodBase64URL);
+    if (base64_url_checks.length > 0) {
+        const base64_url_schema = z4.base64url();
+        base64_url_schema._zod.def.checks = checks;
+        return generate(base64_url_schema, ctx);
+    }
+
+    const base64_checks = checks.filter((c) => c instanceof z4.ZodBase64);
+    if (base64_checks.length > 0) {
+        const base64_schema = z4.base64();
+        base64_schema._zod.def.checks = checks;
+        return generate(base64_schema, ctx);
+    }
+
+
+
+    return null;
 }

--- a/packages/zocker/src/lib/v4/generators/string/legacy.ts
+++ b/packages/zocker/src/lib/v4/generators/string/legacy.ts
@@ -166,6 +166,27 @@ export function legacyFormatString(schema: z.$ZodString, ctx: GenerationContext<
     }
 
 
+    const jwt_checks = checks.filter((c) => c instanceof z4.ZodJWT);
+    if (jwt_checks.length > 0) {
+        const jwt_schema = z4.jwt();
+        jwt_schema._zod.def.checks = checks;
+        return generate(jwt_schema, ctx);
+    }
+
+
+    const ksuid_checks = checks.filter((c) => c instanceof z4.ZodKSUID);
+    if (ksuid_checks.length > 0) {
+        const ksuid_schema = z4.ksuid();
+        ksuid_schema._zod.def.checks = checks;
+        return generate(ksuid_schema, ctx);
+    }
+
+    const xid_checks = checks.filter((c) => c instanceof z4.ZodXID);
+    if (xid_checks.length > 0) {
+        const xid_schema = z4.xid();
+        xid_schema._zod.def.checks = checks;
+        return generate(xid_schema, ctx);
+    }
 
     return null;
 }

--- a/packages/zocker/src/lib/v4/generators/string/legacy.ts
+++ b/packages/zocker/src/lib/v4/generators/string/legacy.ts
@@ -1,0 +1,25 @@
+import z4 from "zod/v4";
+import * as z from "zod/v4/core";
+import { generate, GenerationContext } from "../../generate.js";
+
+/**
+ * If the schema has checks for a legacy format (eg `z.string().email()` instead of `z.string()`), this will
+ * call the apropriate generator. 
+ * 
+ * @returns The generated string, or `null` if no legacy format was used
+ */
+export function legacyFormatString(schema: z.$ZodString, ctx: GenerationContext<any>): string | null {
+    const checks = schema._zod.def.checks ?? [];
+    
+    const guid_checks = checks.filter((c) => c instanceof z4.ZodGUID);
+    const uuid_checks = checks.filter((c) => c instanceof z4.ZodUUID);
+
+    if (uuid_checks.length > 0) {
+        
+        const uuid_schema = z4.uuid({ version: uuid_checks[0]!.def.version })
+        return generate(uuid_schema, ctx);
+    }
+
+
+	return null;
+}

--- a/packages/zocker/src/lib/v4/generators/string/plain.ts
+++ b/packages/zocker/src/lib/v4/generators/string/plain.ts
@@ -14,11 +14,18 @@ import {
 import Randexp from "randexp";
 import { pick } from "../../utils/random.js";
 import { SemanticFlag } from "../../semantics.js";
+import z4 from "zod/v4";
+import { legacyFormatString } from "./legacy.js";
 
 const generate_string: Generator<z.$ZodString> = (string_schema, ctx) => {
+	const legacy = legacyFormatString(string_schema, ctx);
+	if (legacy !== null) return legacy;
+	
 	const lengthConstraints = getLengthConstraints(string_schema);
 	const contentConstraints = getContentConstraints(string_schema);
 	const regexConstraints = getRegexConstraints(string_schema);
+
+	console.log(string_schema._zod.def);
 
 	if (regexConstraints.length > 0) {
 		if (regexConstraints.length > 1)
@@ -144,7 +151,7 @@ function generateStringWithoutFormat(
 		word: faker.lorem.word,
 		jobtitle: faker.person.jobTitle,
 		color: color,
-		gender:faker.person.gender,
+		gender: faker.person.gender,
 		municipality: faker.location.city,
 		"color-hex": () => faker.color.rgb({ prefix: '#', casing: 'lower' }),
 		weekday: faker.date.weekday,
@@ -184,3 +191,5 @@ function stringMatchesConstraints(
 
 	return true;
 }
+
+

--- a/packages/zocker/src/lib/v4/generators/string/plain.ts
+++ b/packages/zocker/src/lib/v4/generators/string/plain.ts
@@ -25,8 +25,6 @@ const generate_string: Generator<z.$ZodString> = (string_schema, ctx) => {
 	const contentConstraints = getContentConstraints(string_schema);
 	const regexConstraints = getRegexConstraints(string_schema);
 
-	console.log(string_schema._zod.def);
-
 	if (regexConstraints.length > 0) {
 		if (regexConstraints.length > 1)
 			throw new NoGeneratorException(

--- a/packages/zocker/tests/v4/deprecated-string-formats.test.ts
+++ b/packages/zocker/tests/v4/deprecated-string-formats.test.ts
@@ -4,9 +4,11 @@ import { test_schema_generation } from "./utils";
 
 const formatted_string_schemas = {
     "string.date": z.string().date(),
-    "string.datetime": z.string().datetime(),
+    "string.datetime": z.string().datetime({ offset: false }),
+    "string.datetime with offset": z.string().datetime({ offset: true }),
     "string.duration": z.string().duration(),
     "string.time": z.string().time(),
+
     "string.email": z.string().email(),
     "string.guid": z.string().guid(),
     "string.uuid": z.string().uuid(),
@@ -18,9 +20,9 @@ const formatted_string_schemas = {
     "string.cuid2": z.string().cuid2(),
     "string.ulid": z.string().ulid(),
     "string.emoji": z.string().emoji(),
-    "string.xid": z.string().xid(),
+   // "string.xid": z.string().xid(),
     "string.nanoid": z.string().nanoid(),
-    "string.ksuid": z.string().ksuid(),
+  //  "string.ksuid": z.string().ksuid(),
     "string.ipv6": z.string().ipv6(),
     "string.ipv4": z.string().ipv4(),
     "string.e164": z.string().e164(),
@@ -28,7 +30,7 @@ const formatted_string_schemas = {
     "string.cidrv6": z.string().cidrv6(),
     "string.base64url": z.string().base64url(),
     "string.base64": z.string().base64(),
-    "string.jwt": z.string().jwt(),
+  //  "string.jwt": z.string().jwt(),
 } as const;
 
 describe("Deprecated string formats", () => {

--- a/packages/zocker/tests/v4/deprecated-string-formats.test.ts
+++ b/packages/zocker/tests/v4/deprecated-string-formats.test.ts
@@ -1,0 +1,24 @@
+import { describe } from "vitest";
+import { z } from "zod/v4";
+import { test_schema_generation } from "./utils";
+
+const formatted_string_schemas = {
+    "string.date": z.string().date(),
+    "string.datetime": z.string().datetime(),
+    "string.duration": z.string().duration(),
+    "string.email": z.string().email(),
+    "string.guid": z.string().guid(),
+    "string.uuid": z.string().uuid(),
+    "string.uuidv4": z.string().uuidv4(),
+    "string.uuidv6": z.string().uuidv6(),
+    "string.uuidv7": z.string().uuidv7(),
+    "string.url": z.string().url(),
+    "string.cuid": z.string().cuid(),
+    "string.cuid2": z.string().cuid2(),
+    "string.ulid": z.string().ulid(),
+    "string.emoji": z.string().emoji(),
+} as const;
+
+describe("Deprecated string formats", () => {
+	test_schema_generation(formatted_string_schemas);
+});

--- a/packages/zocker/tests/v4/deprecated-string-formats.test.ts
+++ b/packages/zocker/tests/v4/deprecated-string-formats.test.ts
@@ -22,7 +22,7 @@ const formatted_string_schemas = {
     "string.emoji": z.string().emoji(),
    // "string.xid": z.string().xid(),
     "string.nanoid": z.string().nanoid(),
-  //  "string.ksuid": z.string().ksuid(),
+    "string.ksuid": z.string().ksuid(),
     "string.ipv6": z.string().ipv6(),
     "string.ipv4": z.string().ipv4(),
     "string.e164": z.string().e164(),

--- a/packages/zocker/tests/v4/deprecated-string-formats.test.ts
+++ b/packages/zocker/tests/v4/deprecated-string-formats.test.ts
@@ -6,6 +6,7 @@ const formatted_string_schemas = {
     "string.date": z.string().date(),
     "string.datetime": z.string().datetime(),
     "string.duration": z.string().duration(),
+     "string.time": z.string().time(),
     "string.email": z.string().email(),
     "string.guid": z.string().guid(),
     "string.uuid": z.string().uuid(),
@@ -17,6 +18,16 @@ const formatted_string_schemas = {
     "string.cuid2": z.string().cuid2(),
     "string.ulid": z.string().ulid(),
     "string.emoji": z.string().emoji(),
+    "string.xid": z.string().xid(),
+    "string.nanoid": z.string().nanoid(),
+    "string.ksuid": z.string().ksuid(),
+    "string.ipv6": z.string().ipv6(),
+    "string.ipv4": z.string().ipv4(),
+    "string.e164": z.string().e164(),
+    "string.cidrv4": z.string().cidrv4(),
+    "string.cidrv6": z.string().cidrv6(),
+    "string.base64url": z.string().base64url(),
+    "string.base64": z.string().base64(),
 } as const;
 
 describe("Deprecated string formats", () => {

--- a/packages/zocker/tests/v4/deprecated-string-formats.test.ts
+++ b/packages/zocker/tests/v4/deprecated-string-formats.test.ts
@@ -6,7 +6,7 @@ const formatted_string_schemas = {
     "string.date": z.string().date(),
     "string.datetime": z.string().datetime(),
     "string.duration": z.string().duration(),
-     "string.time": z.string().time(),
+    "string.time": z.string().time(),
     "string.email": z.string().email(),
     "string.guid": z.string().guid(),
     "string.uuid": z.string().uuid(),
@@ -28,8 +28,9 @@ const formatted_string_schemas = {
     "string.cidrv6": z.string().cidrv6(),
     "string.base64url": z.string().base64url(),
     "string.base64": z.string().base64(),
+    "string.jwt": z.string().jwt(),
 } as const;
 
 describe("Deprecated string formats", () => {
-	test_schema_generation(formatted_string_schemas);
+    test_schema_generation(formatted_string_schemas);
 });

--- a/packages/zocker/tests/v4/ksuid.test.ts
+++ b/packages/zocker/tests/v4/ksuid.test.ts
@@ -1,0 +1,11 @@
+import { describe } from "vitest";
+import { z } from "zod/v4";
+import { test_schema_generation } from "./utils";
+
+const ksuid_schemas = {
+	"plain ksuid": z.ksuid(),
+};
+
+describe("KSUID generation", () => {
+	test_schema_generation(ksuid_schemas);
+});


### PR DESCRIPTION
Closes #33 

This PR adds back support for legacy string formats, such as `z.string().email()`. You should still migrate to the dedicated format schemas (eg: `z.email()`) if possible. 