### PR TITLE
Fix #42

### DIFF
--- a/.changeset/lucky-rats-wear.md
+++ b/.changeset/lucky-rats-wear.md
@@ -1,0 +1,5 @@
+---
+"zocker": patch
+---
+
+Fix [#42](https://github.com/LorisSigrist/zocker/issues/42) - `z.uuid()` no longer generates `00000000-0000-0000-0000-000000000000` as often

--- a/packages/zocker/src/lib/v4/generators/string/uuid.ts
+++ b/packages/zocker/src/lib/v4/generators/string/uuid.ts
@@ -6,6 +6,8 @@ import Randexp from "randexp";
 
 const uuid_generator: Generator<z.$ZodUUID> = (schema, ctx) => {
 	const version = Number.parseInt(schema._zod.def.version?.slice(1) ?? "4");
+	if (version == 4 || !version) return faker.string.uuid(); // faker always returns v4
+	
 	const pattern = schema._zod.def.pattern ?? z.regexes.uuid(version);
 
 	const randexp = new Randexp(pattern);


### PR DESCRIPTION
Closes #42 

Fixes the uuid-v4 generator generating `00000000-0000-0000-0000-000000000000` about half the time when using zod 4