### PR TITLE
Fix `multipleOf` failing when non-integer values are used

### DIFF
--- a/.changeset/neat-parrots-drum.md
+++ b/.changeset/neat-parrots-drum.md
@@ -1,0 +1,5 @@
+---
+"zocker": patch
+---
+
+Correctly handle `multipleOf` constraints on numbers with non-integer multiples- Closes [#50](https://github.com/LorisSigrist/zocker/issues/50)

--- a/packages/zocker/src/lib/v4/generators/numbers.ts
+++ b/packages/zocker/src/lib/v4/generators/numbers.ts
@@ -3,7 +3,6 @@ import { z as z4 } from "zod/v4";
 import { faker } from "@faker-js/faker";
 import { InstanceofGeneratorDefinition } from "../zocker.js";
 import { Generator } from "../generate.js";
-import { weighted_random_boolean } from "../utils/random.js";
 import { lcm } from "../utils/lcm.js";
 import { InvalidSchemaException } from "../exceptions.js";
 import { SemanticFlag } from "../semantics.js";
@@ -53,9 +52,7 @@ const generate_number: Generator<z.$ZodNumber> = (number_schema, ctx) => {
 		return result.value;
 	} catch (e) { }
 
-	let is_extreme_value = weighted_random_boolean(
-		ctx.number_options.extreme_value_chance
-	);
+	let is_extreme_value = faker.datatype.boolean({ probability: ctx.number_options.extreme_value_chance });
 
 	const formatChecks: z.$ZodCheckNumberFormat[] =
 		number_schema._zod.def.checks?.filter(
@@ -131,7 +128,7 @@ const generate_number: Generator<z.$ZodNumber> = (number_schema, ctx) => {
 		value = faker.number.int({ min, max });
 	} else {
 		if (is_extreme_value) {
-			const use_lower_extreme = weighted_random_boolean(0.5);
+			const use_lower_extreme = faker.datatype.boolean({ probability: 0.5});
 			if (use_lower_extreme) value = is_finite ? -Infinity : min;
 			else value = is_finite ? Infinity : max;
 		}

--- a/packages/zocker/src/lib/v4/utils/lcm.ts
+++ b/packages/zocker/src/lib/v4/utils/lcm.ts
@@ -39,6 +39,31 @@ function bigintLCM(a: bigint, b: bigint) {
  * @example "0.75" -> [3n, 4n]
  */
 function decimalToFraction(decimalStr: string): [bigint, bigint] {
+
+    // Handle e-notation
+    if (decimalStr.includes('e')) {
+        const [base, exponent] = decimalStr.split('e');
+        if(!base || !exponent) throw new Error(`Invalid number string: ${decimalStr}`);
+        console.log(`Base: ${base}, Exponent: ${exponent}`);
+        
+        // get the fractional representation of the base
+        const baseFraction = decimalToFraction(base);
+        
+        // the part after the 'e' is the exponent.
+        // may be negative or positive
+        const exponentValue = BigInt(exponent); 
+        
+        // if the exponent is negative we scale the denominator up
+        // if the exponent is positive we scale the numerator up
+        if (exponentValue < 0n) {
+            baseFraction[1] *= 10n ** -exponentValue; // Scale denominator
+        } else {
+            baseFraction[0] *= 10n ** exponentValue; // Scale numerator
+        }
+        
+        return baseFraction;
+    }
+
     // handle integers directly
     if (!decimalStr.includes('.')) return [BigInt(decimalStr), 1n];
 

--- a/packages/zocker/src/lib/v4/utils/lcm.ts
+++ b/packages/zocker/src/lib/v4/utils/lcm.ts
@@ -1,0 +1,81 @@
+
+/**
+ * Calculates the least common multiple (LCM) of two numbers.
+ * @param a
+ * @param b 
+ * @returns 
+ */
+export function lcm<N extends bigint | number>(a: N, b: N): N {
+    if (a === Number.MIN_VALUE || a == 0) return b as N;
+    if (b === Number.MIN_VALUE || b == 0) return a as N;
+
+    if (typeof a === 'bigint') return bigintLCM(BigInt(a), BigInt(b)) as N;
+    
+    return lcmNonIntegers(a.toString(), b.toString()) as N;
+}
+
+/**
+ * Calculates the greatest common divisor (GCD) of two numbers using the Euclidean algorithm.
+ */
+function bigintGCD(a: bigint, b: bigint) : bigint {
+    while (b !== 0n) {
+        [a, b] = [b, a % b];
+    }
+    return a;
+}
+
+/**
+ * Calculates the least common multiple (LCM) of two numbers.
+ */
+function bigintLCM(a: bigint, b: bigint) {
+    return (a * b) / bigintGCD(a, b);
+}
+
+/**
+ * Converts a decimal string to a fraction represented as a tuple of two bigints (numerator, denominator).
+ * @param decimalStr Eg "0.75" or "1.5"
+ * @returns A tuple where the first element is the numerator and the second element is the denominator.
+ * 
+ * @example "0.75" -> [3n, 4n]
+ */
+function decimalToFraction(decimalStr: string): [bigint, bigint] {
+    // handle integers directly
+    if (!decimalStr.includes('.')) return [BigInt(decimalStr), 1n];
+
+    // Handle numbers with decimal points
+    const parts = decimalStr.split('.');
+    const intPart = parts[0];
+    const fracPart = parts[1] ?? "";
+    const scale = 10n ** BigInt(fracPart.length);
+    const numerator = BigInt(intPart + fracPart);
+    const denominator = scale;
+
+    const divisor = bigintGCD(numerator, denominator);
+    return [numerator / divisor, denominator / divisor];
+}
+
+/**
+ * 
+ * @param aStr 
+ * @param bStr 
+ * @returns 
+ */
+function lcmNonIntegers(aStr: string, bStr: string) {
+    // Convert to fractions
+    const [numA, denA] = decimalToFraction(aStr);
+    const [numB, denB] = decimalToFraction(bStr);
+
+    // Find LCM of denominators
+    const lcmDen = bigintLCM(denA, denB);
+
+    // Convert both numbers to integer equivalents
+    const A = (numA * (lcmDen / denA));
+    const B = (numB * (lcmDen / denB));
+
+    // Find integer LCM
+    const lcmInt = bigintLCM(A, B);
+
+    // Divide back to get final result
+    const result = Number(lcmInt) / Number(lcmDen);
+    return Number(result.toString());
+}

--- a/packages/zocker/tests/setup.ts
+++ b/packages/zocker/tests/setup.ts
@@ -1,0 +1,69 @@
+import { beforeEach, afterEach, vi } from 'vitest'
+
+// Check if we're running in CI environment
+const isCI = process.env.CI === 'true' || 
+             process.env.GITHUB_ACTIONS === 'true' || 
+             process.env.GITLAB_CI === 'true' || 
+             process.env.BUILDKITE === 'true' ||
+             process.env.CIRCLECI === 'true' ||
+             process.env.TRAVIS === 'true' ||
+             process.env.NODE_ENV === 'ci'
+
+// You can also override this with a specific environment variable
+const strictConsoleMode = isCI || process.env.VITEST_STRICT_CONSOLE === 'true'
+
+if (strictConsoleMode) {
+  let originalMethods: Record<string, any> = {}
+  
+  // Store original console methods
+  beforeEach(() => {
+    originalMethods = {
+      log: console.log,
+      warn: console.warn,
+      info: console.info,
+      debug: console.debug,
+    }
+    
+    // Replace console methods with error-throwing versions
+    const createStrictConsoleMethod = (methodName: string) => {
+      return vi.fn().mockImplementation((...args: any[]) => {
+        // Create a nice error message showing what was logged
+        const message = args.map(arg => {
+          try {
+            return typeof arg === 'string' ? arg : JSON.stringify(arg, null, 2)
+          } catch {
+            return String(arg)
+          }
+        }).join(' ')
+        
+        // Get stack trace to show where the console method was called
+        const stack = new Error().stack?.split('\n').slice(2).join('\n') || ''
+        
+        throw new Error(
+          `console.${methodName}() usage detected in tests. This is not allowed in CI environments.\n\n` +
+          `Logged message: ${message}\n\n` +
+          `Called from:\n${stack}\n\n` +
+          `Please remove console.${methodName} statements from your tests or use proper testing assertions instead.\n` +
+          `Tip: Use expect().toBe() or other Vitest assertions for testing output.`
+        )
+      })
+    }
+    
+    console.log = createStrictConsoleMethod('log')
+    console.warn = createStrictConsoleMethod('warn') 
+    console.info = createStrictConsoleMethod('info')
+    console.debug = createStrictConsoleMethod('debug')
+    
+    // Note: We typically don't restrict console.error as it's often used for legitimate error reporting
+    // But you can uncomment the next line if you want to restrict it too:
+    // console.error = createStrictConsoleMethod('error')
+  })
+  
+  // Restore original methods after each test
+  afterEach(() => {
+    console.log = originalMethods.log
+    console.warn = originalMethods.warn
+    console.info = originalMethods.info
+    console.debug = originalMethods.debug
+  })
+}

--- a/packages/zocker/tests/v4/lcm.test.ts
+++ b/packages/zocker/tests/v4/lcm.test.ts
@@ -1,0 +1,24 @@
+import { lcm } from "../../src/lib/v4/utils/lcm.js";
+import { describe, it, expect } from "vitest";
+
+describe("LCM", () => {
+    it("works for integers", () => {
+        const result = lcm(3, 5);
+        expect(result).toBe(15);
+    });
+
+    it("works for non-integers where one is a multiple of the other", () => {
+        const result = lcm(0.1, 0.2);
+        expect(result).toBe(0.2);
+    });
+
+    it("works for non-integers where neither is a multiple of the other", () => {
+        const result = lcm(0.3, 0.4);
+        expect(result).toBe(1.2);
+    });
+
+    it("works for mixed integers and non-integers", () => {
+        const result = lcm(2, 0.5);
+        expect(result).toBe(2);
+    });
+});

--- a/packages/zocker/tests/v4/numbers.test.ts
+++ b/packages/zocker/tests/v4/numbers.test.ts
@@ -43,6 +43,10 @@ const number_schemas = {
 		.multipleOf(2.3e-14)
 		.min(55)
 		.max(100),
+	"number with very large multipleof": z
+		.number()
+		.multipleOf(1e14)
+		.min(1), // disallow 0 
 	"number with multiple mins and maxs": z
 		.number()
 		.min(10)

--- a/packages/zocker/tests/v4/numbers.test.ts
+++ b/packages/zocker/tests/v4/numbers.test.ts
@@ -46,7 +46,9 @@ const number_schemas = {
 	"number with very large multipleof": z
 		.number()
 		.multipleOf(1e14)
-		.min(1), // disallow 0 
+		.multipleOf(1e15)
+		.min(1)
+		.max(1e16),
 	"number with multiple mins and maxs": z
 		.number()
 		.min(10)

--- a/packages/zocker/tests/v4/numbers.test.ts
+++ b/packages/zocker/tests/v4/numbers.test.ts
@@ -18,8 +18,8 @@ const number_schemas = {
 	"number gt": z.number().gt(10),
 	"integer lte": z.number().int().lte(10),
 	"integer gte": z.number().int().gte(10),
-	"integer lt": z.number().int().lt(10),
-	"integer gt": z.number().int().gt(10),
+	"integer lt": z.number().int().lt(0),
+	"integer gt": z.number().int().gt(10.6),
 	"number multipleof": z.number().multipleOf(10),
 	"integer multipleof": z.number().int().multipleOf(10),
 	"interger mutliple multipleof": z
@@ -28,6 +28,16 @@ const number_schemas = {
 		.multipleOf(10)
 		.multipleOf(5)
 		.multipleOf(3),
+	"non-integer multipleof": z.number().multipleOf(0.01).multipleOf(0.1),
+	"integer with multipleof and min and max": z.number()
+		.int()
+		.multipleOf(10)
+		.min(10_000)
+		.max(20_000),
+	"non-integer multipleof with min and max": z.number()
+		.multipleOf(0.1)
+			.min(1.5)
+			.max(2.5),
 	"number with multiple mins and maxs": z
 		.number()
 		.min(10)

--- a/packages/zocker/tests/v4/numbers.test.ts
+++ b/packages/zocker/tests/v4/numbers.test.ts
@@ -37,7 +37,12 @@ const number_schemas = {
 	"non-integer multipleof with min and max": z.number()
 		.multipleOf(0.1)
 			.min(1.5)
-			.max(2.5),
+		.max(2.5),
+	"number with small multipleof": z
+		.number()
+		.multipleOf(2.3e-14)
+		.min(55)
+		.max(100),
 	"number with multiple mins and maxs": z
 		.number()
 		.min(10)

--- a/packages/zocker/vitest.config.ts
+++ b/packages/zocker/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // Run setup files before each test suite
+    setupFiles: ['./tests/setup.ts'],
+  },
+})


### PR DESCRIPTION
Closes #50

This PR changes how the `multipleOf` check is met by Zocker. It now 
- Correctly calculates the multipleof non-integer bases
- Confirms that the multipleOf check is actually met. Floating point issues can cause a "valid" multipleof to be rejected by Zod. For example: 2.3 is mathematically a multiple of 0.1, but zod will reject it. Zocker now checks if zod will accept a proposed number & retries if it doesn't.
- Symbolically calculates the LCM if multiple `multipleOf` checks are used