### PR TITLE
fix: update override method to support core Zod types

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,6 @@ Let's override the number generation to only return `Infinity`, regardless of an
 const data = zocker(my_schema).override(z.ZodNumber, Infinity).generate();
 ```
 
-> There is currently an issue, where the types don't play well when passing the classes themselves as arguments. If you get a type-error on `z.$ZodNumber`, type-cast it to itself it with `z.$ZodNumber as any as z.$ZodNumber`. It's silly, I know. If you know how to fix it, contributions are welcome.
-
 In practice you would probably want to return different values based on the exact number-schema we are working on.
 To do that, you can provide a function to the override. It will recieve two arguments, first the schema that we are working on, and second, a generation-context. You usually only utilize the first one.
 

--- a/packages/zocker/src/lib/v4/zocker.ts
+++ b/packages/zocker/src/lib/v4/zocker.ts
@@ -129,8 +129,8 @@ export class Zocker<Z extends z.$ZodType> {
 	override<S extends z.$ZodTypes | KNOWN_OVERRIDE_NAMES | z.$constructor<any>>(
 		schema: S,
 		generator:
-			| Generator<S extends KNOWN_OVERRIDE_NAMES ? OVERRIDE<S> : S extends z.$ZodType ? S : z.$ZodAny>
-			| z.infer<S extends KNOWN_OVERRIDE_NAMES ? OVERRIDE<S> : S extends z.$ZodType ? S : z.$ZodAny>
+			| Generator<S extends KNOWN_OVERRIDE_NAMES ? OVERRIDE<S> : S extends z.$constructor<infer T> ? T : S extends z.$ZodType ? S : z.$ZodType>
+			| z.infer<S extends KNOWN_OVERRIDE_NAMES ? OVERRIDE<S> : S extends z.$constructor<infer T> ? T : S extends z.$ZodType ? S : z.$ZodType>
 	) {
 		const next = this.clone();
 		const generator_function =

--- a/packages/zocker/src/lib/v4/zocker.ts
+++ b/packages/zocker/src/lib/v4/zocker.ts
@@ -126,19 +126,19 @@ export class Zocker<Z extends z.$ZodType> {
 	 * @param schema - Which schema to override. E.g: `z.ZodNumber`.
 	 * @param generator - A value, or a function that generates a value that matches the schema
 	 */
-	override<S extends z.$ZodTypes | KNOWN_OVERRIDE_NAMES>(
+	override<S extends z.$ZodTypes | KNOWN_OVERRIDE_NAMES | z.$constructor<any>>(
 		schema: S,
 		generator:
-			| Generator<S extends KNOWN_OVERRIDE_NAMES ? OVERRIDE<S> : S>
-			| z.infer<S extends KNOWN_OVERRIDE_NAMES ? OVERRIDE<S> : S>
+			| Generator<S extends KNOWN_OVERRIDE_NAMES ? OVERRIDE<S> : S extends z.$ZodType ? S : z.$ZodAny>
+			| z.infer<S extends KNOWN_OVERRIDE_NAMES ? OVERRIDE<S> : S extends z.$ZodType ? S : z.$ZodAny>
 	) {
 		const next = this.clone();
 		const generator_function =
 			typeof generator === "function" ? generator : () => generator;
 
-		const resolved_schema: z.$ZodTypes =
+		const resolved_schema =
 			typeof schema !== "string"
-				? schema
+				? schema as z.$ZodTypes
 				: OVERRIDE_NAMES[schema as KNOWN_OVERRIDE_NAMES]!;
 		next.instanceof_generators = [
 			{

--- a/packages/zocker/src/lib/v4/zocker.ts
+++ b/packages/zocker/src/lib/v4/zocker.ts
@@ -129,8 +129,8 @@ export class Zocker<Z extends z.$ZodType> {
 	override<S extends z.$ZodTypes | KNOWN_OVERRIDE_NAMES | z.$constructor<any>>(
 		schema: S,
 		generator:
-			| Generator<S extends KNOWN_OVERRIDE_NAMES ? OVERRIDE<S> : S extends z.$constructor<infer T> ? T : S extends z.$ZodType ? S : z.$ZodType>
-			| z.infer<S extends KNOWN_OVERRIDE_NAMES ? OVERRIDE<S> : S extends z.$constructor<infer T> ? T : S extends z.$ZodType ? S : z.$ZodType>
+			| Generator<S extends KNOWN_OVERRIDE_NAMES ? OVERRIDE<S> : S extends z.$constructor<infer T> ? T : S>
+			| z.infer<S extends KNOWN_OVERRIDE_NAMES ? OVERRIDE<S> : S extends z.$constructor<infer T> ? T : S>
 	) {
 		const next = this.clone();
 		const generator_function =

--- a/packages/zocker/tests/v4/override.test.ts
+++ b/packages/zocker/tests/v4/override.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { zocker } from "../../src";
 import { z } from "zod/v4";
+import * as core from "zod/v4/core";
 
 describe("Override", () => {
 	it("works", () => {
@@ -11,6 +12,32 @@ describe("Override", () => {
 
 		const generated = zocker(schema)
 			.override("number", (schema) => 5)
+			.generate();
+
+		expect(generated.age).toBe(5);
+	});
+
+	it("works(class)", () => {
+		const schema = z.object({
+			name: z.string(),
+			age: z.number()
+		});
+
+		const generated = zocker(schema)
+			.override(z.ZodNumber, (schema) => 5)
+			.generate();
+
+		expect(generated.age).toBe(5);
+	});
+
+	it("works(core class)", () => {
+		const schema = z.object({
+			name: z.string(),
+			age: z.number()
+		});
+
+		const generated = zocker(schema)
+			.override(core.$ZodNumber, (schema) => 5)
 			.generate();
 
 		expect(generated.age).toBe(5);


### PR DESCRIPTION
## Background
The current documentation mentions a known type issue when using the override method with Zod classes:

> There is currently an issue, where the types don't play well when passing the classes themselves as arguments. If you get a type-error on `z.$ZodNumber`, type-cast it to itself it with `z.$ZodNumber as any as z.$ZodNumber`.

## Problem
When overriding built-in generators using Zod classes like `z.ZodNumber`, TypeScript treats these classes as constructor functions that return class instances, rather than types that extend `z.ZodTypes`. This causes type errors when trying to pass them as the schema parameter to the override method.

https://github.com/colinhacks/zod/blob/39c5f71c92b9c4c39fc0a59b9375204fa140eaf0/packages/zod/src/v4/core/schemas.ts#L1003-L1009

## Solution
Modified the schema parameter type in the override method to accept Zod constructors in addition to the existing types. This allows users to pass Zod classes directly without requiring type casting workarounds.


Thank you for creating and maintaining this useful library! 
Please feel free to let me know if there are any issues with this approach or if you'd prefer a different solution. If this doesn't align with your vision for the project, please don't hesitate to close this PR - no worries at all!