### PR TITLE
chore: update color generator to use faker.color.rgb

### DIFF
--- a/packages/zocker/src/lib/v4/generators/string/plain.ts
+++ b/packages/zocker/src/lib/v4/generators/string/plain.ts
@@ -170,7 +170,7 @@ function generateStringWithoutFormat(
 }
 
 function color(): string {
-	const generators = [faker.color.human, faker.internet.color];
+	const generators = [faker.color.human, faker.color.rgb];
 	return pick(generators)();
 }
 


### PR DESCRIPTION
### Summary

Replace the deprecated `faker.internet.color` API with `faker.color.rgb` to maintain compatibility with newer versions of faker.js.

### Background

The `faker.internet.color` method has been deprecated in recent versions of faker.js. When generating test data for schemas like `z.object({ color: z.string() })`, this results in numerous annoying deprecation warnings:
> [@faker-js/faker]: faker.internet.color() is deprecated since v9.6.0 and will be removed in v10.0.0. Please use faker.color.rgb() instead.

