### PR TITLE
Fix Support for Zod 3 schemas

### DIFF
--- a/.changeset/violet-windows-change.md
+++ b/.changeset/violet-windows-change.md
@@ -1,0 +1,5 @@
+---
+"zocker": patch
+---
+
+Fix support for legacy zod 3 schemas - [#57](https://github.com/LorisSigrist/zocker/issues/57)

--- a/packages/e2e-zod3/index.js
+++ b/packages/e2e-zod3/index.js
@@ -1,0 +1,14 @@
+const { z } = require("zod");
+const { zocker } = require("zocker");
+
+const schema = z.object({
+	id: z.string().uuid(),
+	name: z.string(),
+	age: z.number().int().min(0).max(120),
+	email: z.string().email(),
+	isActive: z.boolean().optional()
+});
+
+const data = zocker(schema).generate();
+if (!data) throw new Error("Data generation failed");
+console.log("Zod3 CJS Generated Data:", data);

--- a/packages/e2e-zod3/package.json
+++ b/packages/e2e-zod3/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "e2e-zod3",
+    "version": "0.0.1",
+    "private": true,
+    "description": "End-to-end tests for Zod 3",
+    "main": "index.js",
+    "scripts": {
+        "test": "node ./index.js"
+    },
+    "dependencies": {
+		"zocker": "workspace:*",
+		"zod": "3.25.3"
+	}
+}

--- a/packages/zocker/src/lib/v3/generate.ts
+++ b/packages/zocker/src/lib/v3/generate.ts
@@ -83,7 +83,24 @@ const generate_value: Generator<z.ZodSchema> = (schema, generation_context) => {
 
 	//Check if an instanceof generator is available for this schema
 	const instanceof_generator = generation_context.instanceof_generators.find(
-		(g) => schema instanceof (g.schema as any)
+		generator => {
+			// If the schema is a class, we can check if it is an instance of the generator's schema
+			if (schema instanceof generator.schema) return true;
+
+			// For some reason, zod3 schemas from zod4 do not have the same instance.
+			// In this case we check if the schema's typeName matches the generator's schema name.
+
+			const generatorSchemaName : string | undefined = generator.schema.name;
+			const schemaTypeName: string | undefined = (schema._def as any)?.typeName;
+			
+			if (generatorSchemaName && schemaTypeName) {
+				return generatorSchemaName === schemaTypeName;
+			}
+
+			// Failed
+			return false;
+
+		}
 	);
 	if (instanceof_generator)
 		return instanceof_generator.generator(schema, generation_context);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,15 @@ importers:
         specifier: 'catalog:'
         version: 4.0.14
 
+  packages/e2e-zod3:
+    dependencies:
+      zocker:
+        specifier: workspace:*
+        version: link:../zocker
+      zod:
+        specifier: 3.25.3
+        version: 3.25.3
+
   packages/example:
     dependencies:
       zocker:
@@ -1214,6 +1223,9 @@ packages:
     peerDependencies:
       zod: ^3.25.3
 
+  zod@3.25.3:
+    resolution: {integrity: sha512-VGZqnyYNrl8JpEJRZaFPqeVNIuqgXNu4cXZ5cOb6zEUO1OxKbRnWB4UdDIXMmiERWncs0yDQukssHov8JUxykQ==}
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -2295,6 +2307,8 @@ snapshots:
       '@faker-js/faker': 9.8.0
       randexp: 0.5.3
       zod: 4.0.14
+
+  zod@3.25.3: {}
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
This PR fixes support for legacy Zod3 schemas. 

The way zocker determines which "generator" to use for a given schemas is via an `instanceof` check. For some reason this check was broken by the introduction of zod 4. 

```ts
// old check
z.object({}) instanceof  z.ZodObject // sometimes returns false
```

This PR fixes this by falling back to the schemas String name when checking if a given schemas has a given type.

```ts
// New, additional check
const typeName = z.object()._def.typeName;
typeName == z.ZodObject.name;
```

This PR also adds a new E2E test package that uses zod 3 schemas to ensure this won't regress in the future. 