### PR TITLE
chore: upgrade faker to v10

### DIFF
--- a/.changeset/clear-icons-try.md
+++ b/.changeset/clear-icons-try.md
@@ -1,0 +1,5 @@
+---
+"zocker": major
+---
+
+Upgrade @faker-js/faker to v10, drop node18 support

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/packages/zocker/package.json
+++ b/packages/zocker/package.json
@@ -36,7 +36,7 @@
 		"zod": "catalog:"
 	},
 	"dependencies": {
-		"@faker-js/faker": "^9.8.0",
+		"@faker-js/faker": "^10.0.0",
 		"randexp": "^0.5.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,10 +51,10 @@ importers:
     dependencies:
       zocker:
         specifier: latest
-        version: 2.2.2(zod@4.0.17)
+        version: 2.3.0(zod@4.1.3)
       zod:
         specifier: latest
-        version: 4.0.17
+        version: 4.1.3
     devDependencies:
       typescript:
         specifier: ~5.8.3
@@ -66,8 +66,8 @@ importers:
   packages/zocker:
     dependencies:
       '@faker-js/faker':
-        specifier: ^9.8.0
-        version: 9.8.0
+        specifier: ^10.0.0
+        version: 10.0.0
       randexp:
         specifier: ^0.5.3
         version: 0.5.3
@@ -326,8 +326,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@faker-js/faker@9.8.0':
-    resolution: {integrity: sha512-U9wpuSrJC93jZBxx/Qq2wPjCuYISBueyVUGK7qqdmj7r/nxaxwW8AQDCLeRO7wZnjj94sh3p246cAYjUKuqgfg==}
+  '@faker-js/faker@10.0.0':
+    resolution: {integrity: sha512-UollFEUkVXutsaP+Vndjxar40Gs5JL2HeLcl8xO1QAjJgOdhc3OmBFWyEylS+RddWaaBiAzH+5/17PLQJwDiLw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
+
+  '@faker-js/faker@9.9.0':
+    resolution: {integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==}
     engines: {node: '>=18.0.0', npm: '>=9.0.0'}
 
   '@inquirer/external-editor@1.0.1':
@@ -1218,16 +1222,19 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  zocker@2.2.2:
-    resolution: {integrity: sha512-j9BzLdQTUHn1GznVXRSNECgms2J4C5m831GheHcfTtVbQbBzeRHvx+M2aEffMlveTCYllV4KUvcOghGTc/K1uA==}
+  zocker@2.3.0:
+    resolution: {integrity: sha512-HM8jCcnBlJsZURkr+Pjmqzm8/USTn9IaV0/goclgGnbnY07y74wtNt1/DQFpbyxJuNe9VAGLyP9nOJGeoguoNw==}
     peerDependencies:
-      zod: ^3.25.3 || ^4.0.0
+      zod: ^3.25.0 || ^4.0.0
 
   zod@3.25.3:
     resolution: {integrity: sha512-VGZqnyYNrl8JpEJRZaFPqeVNIuqgXNu4cXZ5cOb6zEUO1OxKbRnWB4UdDIXMmiERWncs0yDQukssHov8JUxykQ==}
 
   zod@4.0.17:
     resolution: {integrity: sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==}
+
+  zod@4.1.3:
+    resolution: {integrity: sha512-1neef4bMce1hNTrxvHVKxWjKfGDn0oAli3Wy1Uwb7TRO1+wEwoZUZNP1NXIEESybOBiFnBOhI6a4m6tCLE8dog==}
 
 snapshots:
 
@@ -1489,7 +1496,9 @@ snapshots:
   '@esbuild/win32-x64@0.25.4':
     optional: true
 
-  '@faker-js/faker@9.8.0': {}
+  '@faker-js/faker@10.0.0': {}
+
+  '@faker-js/faker@9.9.0': {}
 
   '@inquirer/external-editor@1.0.1(@types/node@22.15.19)':
     dependencies:
@@ -2298,12 +2307,14 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  zocker@2.2.2(zod@4.0.17):
+  zocker@2.3.0(zod@4.1.3):
     dependencies:
-      '@faker-js/faker': 9.8.0
+      '@faker-js/faker': 9.9.0
       randexp: 0.5.3
-      zod: 4.0.17
+      zod: 4.1.3
 
   zod@3.25.3: {}
 
   zod@4.0.17: {}
+
+  zod@4.1.3: {}


### PR DESCRIPTION
Faker v10 has been released (see [upgrade guide](https://v10.fakerjs.dev/guide/upgrading.html)).

I am also consuming zocker on a repository locally, and by using pnpm override to force zocker to use v10 instead of v9 produced no issues in our typechecking and testing pipelines.

The only caveat is that faker v10 no longer suppots node v18, so I have removed it from the matrix of testing in the CI workflow file.