### PR TITLE
ability to set SemanitcFlagMap

### DIFF
--- a/packages/zocker/src/lib/v4/generate.ts
+++ b/packages/zocker/src/lib/v4/generate.ts
@@ -7,7 +7,7 @@ import {
 	InstanceofGeneratorDefinition,
 	ReferenceGeneratorDefinition
 } from "./zocker.js";
-import { SemanticFlag } from "./semantics.js";
+import { SemanticFlag, SemanitcFlagMap } from "./semantics.js";
 import { NumberGeneratorOptions } from "./generators/numbers.js";
 import { OptionalOptions } from "./generators/optional.js";
 import { NullableOptions } from "./generators/nullable.js";
@@ -32,6 +32,7 @@ export type GenerationContext<Z extends z.$ZodType> = {
 
 	path: (string | number | symbol)[];
 	semantic_context: SemanticFlag;
+	semantic_flag_map?: SemanitcFlagMap;
 
 	seed: number;
 

--- a/packages/zocker/src/lib/v4/generators/numbers.ts
+++ b/packages/zocker/src/lib/v4/generators/numbers.ts
@@ -5,7 +5,7 @@ import { InstanceofGeneratorDefinition } from "../zocker.js";
 import { Generator } from "../generate.js";
 import { lcm } from "../utils/lcm.js";
 import { InvalidSchemaException } from "../exceptions.js";
-import { SemanticFlag } from "../semantics.js";
+import { SemanticFlagStr } from "../semantics.js";
 
 export type NumberGeneratorOptions = {
 	extreme_value_chance: number;
@@ -25,7 +25,7 @@ const generate_number: Generator<z.$ZodNumber> = (number_schema, ctx) => {
 		let proposed_number = NaN;
 
 		const semantic_generators: {
-			[flag in SemanticFlag]?: () => number;
+			[flag in SemanticFlagStr]?: () => number;
 		} = {
 			age: () => faker.number.int({ min: 0, max: 120 }),
 			year: () => faker.number.int({ min: 1200, max: 3000 }),
@@ -38,7 +38,10 @@ const generate_number: Generator<z.$ZodNumber> = (number_schema, ctx) => {
 			weekday: () => faker.number.int({ min: 0, max: 6 })
 		};
 
-		const generator = semantic_generators[ctx.semantic_context];
+		const generator =
+			typeof ctx.semantic_context === "function"
+				? ctx.semantic_context
+				: semantic_generators[ctx.semantic_context];
 		if (!generator)
 			throw new Error(
 				"No generator found for semantic context - Falling back to random number"

--- a/packages/zocker/src/lib/v4/generators/object.ts
+++ b/packages/zocker/src/lib/v4/generators/object.ts
@@ -23,7 +23,7 @@ const generate_object = <T extends z.$ZodShape>(
 		const property_schema = entry[1] as Value;
 
 		const prev_semantic_context = ctx.semantic_context;
-		const semantic_flag = get_semantic_flag(String(key));
+		const semantic_flag = get_semantic_flag(String(key), ctx.semantic_flag_map);
 
 		try {
 			ctx.path.push(key);

--- a/packages/zocker/src/lib/v4/generators/string/plain.ts
+++ b/packages/zocker/src/lib/v4/generators/string/plain.ts
@@ -13,7 +13,7 @@ import {
 } from "./length-constraints.js";
 import Randexp from "randexp";
 import { pick } from "../../utils/random.js";
-import { SemanticFlag } from "../../semantics.js";
+import { SemanticFlagStr } from "../../semantics.js";
 import z4 from "zod/v4";
 import { legacyFormatString } from "./legacy.js";
 
@@ -134,7 +134,7 @@ function generateStringWithoutFormat(
 	cc: ContentConstraints
 ) {
 	const semantic_generators: {
-		[flag in SemanticFlag]?: () => string;
+		[flag in SemanticFlagStr]?: () => string;
 	} = {
 		fullname: faker.person.fullName,
 		firstname: faker.person.firstName,
@@ -159,7 +159,10 @@ function generateStringWithoutFormat(
 			faker.lorem.paragraphs(faker.number.int({ min: 1, max: 5 }))
 	};
 
-	const generator = semantic_generators[ctx.semantic_context];
+	const generator =
+		typeof ctx.semantic_context === "function"
+			? ctx.semantic_context
+			: semantic_generators[ctx.semantic_context];
 	if (!generator)
 		throw new Error(
 			"No semantic generator found for context - falling back to random string"

--- a/packages/zocker/src/lib/v4/semantics.ts
+++ b/packages/zocker/src/lib/v4/semantics.ts
@@ -1,4 +1,4 @@
-export type SemanticFlag =
+export type SemanticFlagStr =
 	| "unspecified"
 	| "key"
 	| "fullname"
@@ -30,79 +30,92 @@ export type SemanticFlag =
 	| "municipality"
 	| "unique-id";
 
-const paragraph_triggers = [
-	"about",
-	"description",
-	"paragraph",
-	"text",
-	"body",
-	"content"
-];
-const sentence_triggers = ["sentence", "line", "headline", "heading"];
-const jobtitle_triggers = [
-	"job",
-	"title",
-	"position",
-	"role",
-	"occupation",
-	"profession",
-	"career"
-];
+export type SemanticFlag = SemanticFlagStr | (() => any);
 
-const delimiters = [",", ";", ":", "|", "/", "\\", "-", "_", " "];
+export type SemanitcFlagMap = {
+	[key: string | symbol]: SemanticFlag | SemanitcFlagMap;
+};
 
-export function get_semantic_flag(str: string): SemanticFlag {
+const default_semantic_flag_map: SemanitcFlagMap = {
+	name: {
+		first: "firstname",
+		last: "lastname",
+		"": "fullname" // else
+	},
+	street: "street",
+	city: "city",
+	country: "country",
+	// paragraph
+	about: "paragraph",
+	description: "paragraph",
+	paragraph: "paragraph",
+	text: "paragraph",
+	body: "paragraph",
+	content: "paragraph",
+	// sentence
+	sentence: "sentence",
+	line: "sentence",
+	headline: "sentence",
+	heading: "sentence",
+	word: "word",
+	// jobtitle
+	job: "jobtitle",
+	title: "jobtitle",
+	position: "jobtitle",
+	role: "jobtitle",
+	occupation: "jobtitle",
+	profession: "jobtitle",
+	career: "jobtitle",
+	phone: "phoneNumber",
+	age: "age",
+	hex: "color-hex",
+	color: "color",
+	zip: "zip",
+	week: {
+		day: "weekday"
+	},
+	birthday: "birthday",
+	year: "year",
+	month: "month",
+	day: "day-of-the-month",
+	hour: "hour",
+	minute: "minute",
+	second: "second",
+	millisecond: "millisecond",
+	// gender
+	gender: "gender",
+	sex: "gender",
+	// municipality
+	municipality: "municipality",
+	// city: "municipality",
+	town: "municipality",
+	place: "municipality",
+	region: "municipality",
+	state: "municipality",
+	id: "unique-id"
+};
+
+function select_semantic_flag(
+	str: string,
+	semantic_flag_map: SemanitcFlagMap
+): SemanticFlag | undefined {
+	for (const key in Object.keys(semantic_flag_map)) {
+		if (!str.includes(key)) continue;
+		const val = semantic_flag_map[key]!;
+		const res = typeof val === "object" ? select_semantic_flag(str, val) : val;
+		if (res === undefined) continue;
+		return res;
+	}
+}
+
+export function get_semantic_flag(
+	str: string,
+	semantic_flag_map?: SemanitcFlagMap
+): SemanticFlag {
 	str = str.toLowerCase().trim();
-
-	for (const delimiter of delimiters) {
-		str = str.split(delimiter).join(" ");
-	}
-
-	if (str.includes("name")) {
-		if (str.includes("first")) return "firstname";
-		if (str.includes("last")) return "lastname";
-		return "fullname";
-	}
-
-	if (str.includes("street")) return "street";
-	if (str.includes("city")) return "city";
-	if (str.includes("country")) return "country";
-
-	if (paragraph_triggers.some((t) => str.includes(t))) return "paragraph";
-	if (sentence_triggers.some((t) => str.includes(t))) return "sentence";
-	if (str.includes("word")) return "word";
-
-	if (jobtitle_triggers.some((t) => str.includes(t))) return "jobtitle";
-
-	if (str.includes("phone")) return "phoneNumber";
-	if (str.includes("age")) return "age";
-
-	if (str.includes("hex")) return "color-hex";
-	if (str.includes("color")) return "color";
-	if (str.includes("zip")) return "zip";
-
-	if (str.includes("week") && str.includes("day")) return "weekday";
-	if (str.includes("birthday")) return "birthday";
-	if (str.includes("year")) return "year";
-	if (str.includes("month")) return "month";
-	if (str.includes("day")) return "day-of-the-month";
-	if (str.includes("hour")) return "hour";
-	if (str.includes("minute")) return "minute";
-	if (str.includes("second")) return "second";
-	if (str.includes("millisecond")) return "millisecond";
-
-	if (str.includes("gender") || str.includes("sex")) return "gender";
-
-	if (
-		str.includes("municipality") ||
-		str.includes("city") ||
-		str.includes("town") ||
-		str.includes("place") ||
-		str.includes("region") ||
-		str.includes("state")
-	)
-		return "municipality";
-
-	if (str.includes("id")) return "unique-id";
-	return "unspecified";
+	return (
+		(semantic_flag_map && select_semantic_flag(str, semantic_flag_map)) ||
+		select_semantic_flag(str, default_semantic_flag_map) ||
+		"unspecified"
+	);
 }

--- a/packages/zocker/src/lib/v4/zocker.ts
+++ b/packages/zocker/src/lib/v4/zocker.ts
@@ -12,6 +12,7 @@ import { SetOptions } from "./generators/set.js";
 import { AnyOptions } from "./generators/any.js";
 import { ArrayOptions } from "./generators/array.js";
 import { ObjectOptions } from "./generators/object.js";
+import { SemanitcFlagMap } from "./semantics.js";
 
 export type InstanceofGeneratorDefinition<Z extends z.$ZodType> = {
 	schema: Z;
@@ -37,6 +38,7 @@ export class Zocker<Z extends z.$ZodType> {
 	];
 	private reference_generators: ReferenceGeneratorDefinition<any>[] = [];
 	private seed: number | undefined = undefined;
+	private semantic_flag_map?: SemanitcFlagMap;
 	private recursion_limit = 5;
 
 	private number_options: NumberGeneratorOptions = {
@@ -129,8 +131,20 @@ export class Zocker<Z extends z.$ZodType> {
 	override<S extends z.$ZodTypes | KNOWN_OVERRIDE_NAMES | z.$constructor<any>>(
 		schema: S,
 		generator:
-			| Generator<S extends KNOWN_OVERRIDE_NAMES ? OVERRIDE<S> : S extends z.$constructor<infer T> ? T : S>
-			| z.infer<S extends KNOWN_OVERRIDE_NAMES ? OVERRIDE<S> : S extends z.$constructor<infer T> ? T : S>
+			| Generator<
+					S extends KNOWN_OVERRIDE_NAMES
+						? OVERRIDE<S>
+						: S extends z.$constructor<infer T>
+						? T
+						: S
+			  >
+			| z.infer<
+					S extends KNOWN_OVERRIDE_NAMES
+						? OVERRIDE<S>
+						: S extends z.$constructor<infer T>
+						? T
+						: S
+			  >
 	) {
 		const next = this.clone();
 		const generator_function =
@@ -138,7 +152,7 @@ export class Zocker<Z extends z.$ZodType> {
 
 		const resolved_schema =
 			typeof schema !== "string"
-				? schema as z.$ZodTypes
+				? (schema as z.$ZodTypes)
 				: OVERRIDE_NAMES[schema as KNOWN_OVERRIDE_NAMES]!;
 		next.instanceof_generators = [
 			{
@@ -155,6 +169,12 @@ export class Zocker<Z extends z.$ZodType> {
 	setSeed(seed: number) {
 		const next = this.clone();
 		next.seed = seed;
+		return next;
+	}
+
+	setSemanticFlagMap(semantic_flag_map: SemanitcFlagMap) {
+		const next = this.clone();
+		next.semantic_flag_map = semantic_flag_map;
 		return next;
 	}
 
@@ -250,7 +270,9 @@ export class Zocker<Z extends z.$ZodType> {
 			any_options: this.any_options,
 			unknown_options: this.unknown_options,
 			array_options: this.array_options,
-			object_options: this.object_options
+			object_options: this.object_options,
+
+			semantic_flag_map: this.semantic_flag_map
 		};
 
 		faker.seed(ctx.seed);


### PR DESCRIPTION
PR for https://github.com/LorisSigrist/zocker/issues/78

Usage:

```ts
export const xSchema = z.object({
  country_alpha3: z.string().length(3).optional(),
})

zocker(xSchema).setSemanticFlagMap({
  country_alpha3: () => faker.address.countryCode('alpha-3')
}).generate()
```

this is proposal. I can add tests and documentation if you think this is a good idea